### PR TITLE
Refactor passport resource blades for shared layouts

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', 'Passport Change Management')</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    @stack('styles')
+</head>
+<body class="bg-light @yield('body-class', '')">
+    <div class="min-vh-100 d-flex flex-column">
+        <main class="flex-grow-1 @yield('main-class', 'py-5')">
+            @yield('content')
+        </main>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    @stack('scripts')
+</body>
+</html>

--- a/resources/views/layouts/pdf.blade.php
+++ b/resources/views/layouts/pdf.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>@yield('title', config('app.name', 'Document'))</title>
+    @stack('styles')
+</head>
+<body class="@yield('body-class', '')">
+@yield('content')
+</body>
+</html>

--- a/resources/views/passport/edit.blade.php
+++ b/resources/views/passport/edit.blade.php
@@ -1,111 +1,38 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Edit Passport Change</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container my-5">
-    <div class="card p-4 shadow-sm">
-        <h3>Edit Passport Change</h3>
-        <form action="{{ route('passport.update', $passportChange->id) }}" method="POST">
-            @csrf
+@extends('layouts.app')
 
-            <div class="mb-3">
-                <label class="form-label">Serial</label>
-                <input type="text" name="serial" class="form-control" value="{{ old('serial', $passportChange->serial) }}">
-            </div>
+@section('title', 'Edit Passport Change')
 
-            <div class="mb-3">
-                <label class="form-label">Date</label>
-                <input type="date" name="date" class="form-control" value="{{ old('date', $passportChange->date) }}">
-            </div>
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-7">
+            <div class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h3 class="mb-4">Edit Passport Change</h3>
 
-            <div class="mb-3">
-                <label class="form-label">Old Passport Number</label>
-                <input type="text" name="old_passport_number" class="form-control" value="{{ old('old_passport_number', $passportChange->old_passport_number) }}">
-            </div>
+                    @if($errors->any())
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
 
-            <div class="mb-3">
-                <label class="form-label">New Passport Number</label>
-                <input type="text" name="new_passport_number" class="form-control" value="{{ old('new_passport_number', $passportChange->new_passport_number) }}">
-            </div>
+                    <form action="{{ route('passport.update', $passportChange->id) }}" method="POST">
+                        @csrf
 
-            <!-- Name Changed -->
-            <div class="form-check mb-2">
-                <input class="form-check-input change-toggle" type="checkbox" name="name_changed" id="name_changed" data-target="nameFields" {{ $passportChange->name_changed ? 'checked' : '' }}>
-                <label class="form-check-label" for="name_changed">Name Changed</label>
-            </div>
-            <div id="nameFields" class="{{ $passportChange->name_changed ? '' : 'd-none' }} mb-3">
-                <input type="text" name="old_name" placeholder="Old Name" class="form-control mb-2" value="{{ old('old_name', $passportChange->old_name) }}">
-                <input type="text" name="new_name" placeholder="New Name" class="form-control" value="{{ old('new_name', $passportChange->new_name) }}">
-            </div>
+                        @include('passport.partials.form-fields', ['passportChange' => $passportChange])
 
-            <!-- Father Changed -->
-            <div class="form-check mb-2">
-                <input class="form-check-input change-toggle" type="checkbox" name="father_changed" id="father_changed" data-target="fatherFields" {{ $passportChange->father_changed ? 'checked' : '' }}>
-                <label class="form-check-label" for="father_changed">Father's Name Changed</label>
+                        <div class="d-flex justify-content-end gap-2 mt-4">
+                            <button type="submit" class="btn btn-success px-4">Update</button>
+                            <a href="{{ route('passport.index') }}" class="btn btn-secondary px-4">Cancel</a>
+                        </div>
+                    </form>
+                </div>
             </div>
-            <div id="fatherFields" class="{{ $passportChange->father_changed ? '' : 'd-none' }} mb-3">
-                <input type="text" name="old_father_name" placeholder="Old Father's Name" class="form-control mb-2" value="{{ old('old_father_name', $passportChange->old_father_name) }}">
-                <input type="text" name="new_father_name" placeholder="New Father's Name" class="form-control" value="{{ old('new_father_name', $passportChange->new_father_name) }}">
-            </div>
-
-            <!-- Mother Changed -->
-            <div class="form-check mb-2">
-                <input class="form-check-input change-toggle" type="checkbox" name="mother_changed" id="mother_changed" data-target="motherFields" {{ $passportChange->mother_changed ? 'checked' : '' }}>
-                <label class="form-check-label" for="mother_changed">Mother's Name Changed</label>
-            </div>
-            <div id="motherFields" class="{{ $passportChange->mother_changed ? '' : 'd-none' }} mb-3">
-                <input type="text" name="old_mother_name" placeholder="Old Mother's Name" class="form-control mb-2" value="{{ old('old_mother_name', $passportChange->old_mother_name) }}">
-                <input type="text" name="new_mother_name" placeholder="New Mother's Name" class="form-control" value="{{ old('new_mother_name', $passportChange->new_mother_name) }}">
-            </div>
-
-            <!-- DOB Changed -->
-            <div class="form-check mb-2">
-                <input class="form-check-input change-toggle" type="checkbox" name="dob_changed" id="dob_changed" data-target="dobFields" {{ $passportChange->dob_changed ? 'checked' : '' }}>
-                <label class="form-check-label" for="dob_changed">Date of Birth Changed</label>
-            </div>
-            <div id="dobFields" class="{{ $passportChange->dob_changed ? '' : 'd-none' }} mb-3">
-                <input type="date" name="old_dob" class="form-control mb-2" value="{{ old('old_dob', $passportChange->old_dob) }}">
-                <input type="date" name="new_dob" class="form-control" value="{{ old('new_dob', $passportChange->new_dob) }}">
-            </div>
-
-            <h5>Verified By :</h5>
-
-            <!-- NID / BRC -->
-            <div class="form-check mb-2">
-                <input class="form-check-input" type="checkbox" name="nid" id="nid" {{ $passportChange->nid ? 'checked' : '' }}>
-                <label class="form-check-label" for="nid">National Identity Card (NID)</label>
-            </div>
-
-            <div class="form-check mb-3">
-                <input class="form-check-input" type="checkbox" name="brc" id="brc" {{ $passportChange->brc ? 'checked' : '' }}>
-                <label class="form-check-label" for="brc">Birth Certificate (BRC)</label>
-            </div>
-
-
-            <button type="submit" class="btn btn-success">Update</button>
-            <a href="{{ route('passport.index') }}" class="btn btn-secondary">Cancel</a>
-        </form>
+        </div>
     </div>
 </div>
-
-</body>
-<script>
-    document.querySelectorAll('.change-toggle').forEach(toggle => {
-        toggle.addEventListener('change', () => {
-            const targetId = toggle.dataset.target;
-            const target = document.getElementById(targetId);
-            if(toggle.checked){
-                target.classList.remove('d-none');
-            } else {
-                target.classList.add('d-none');
-            }
-        });
-    });
-</script>
-
-</html>
+@endsection

--- a/resources/views/passport/form.blade.php
+++ b/resources/views/passport/form.blade.php
@@ -1,144 +1,37 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Passport Change Form</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container my-5">
-    <h2>Passport Change Form</h2>
-    <form action="{{ route('passport.store') }}" method="POST" class="card p-4 shadow-sm">
-        @csrf
-        <!-- Serial & Date -->
-        <div class="mb-3">
-            <label class="form-label">Serial</label>
-            <input type="text" name="serial" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label class="form-label">Date</label>
-            <input type="date" name="date" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label class="form-label">Name</label>
-            <input type="text" name="name" class="form-control">
-        </div>
+@extends('layouts.app')
 
-        <!-- Passport Numbers (Always Visible) -->
-        <h5>Passport Numbers</h5>
-        <div class="mb-3">
-            <label class="form-label">Old Passport Number</label>
-            <input type="text" name="old_passport_number" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label class="form-label">New Passport Number</label>
-            <input type="text" name="new_passport_number" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label class="form-label">New Passport Issue Date</label>
-            <input type="date" name="new_passport_issue_date" class="form-control">
-        </div>
+@section('title', 'Passport Change Form')
 
-        <!-- Checkboxes -->
-        <h5 class="mt-4">Changes</h5>
-        <div class="form-check">
-            <input class="form-check-input change-toggle" type="checkbox" id="nameChanged" name="name_changed" data-target="nameFields">
-            <label class="form-check-label" for="nameChanged">Name Changed</label>
-        </div>
-        <div class="form-check">
-            <input class="form-check-input change-toggle" type="checkbox" id="fatherChanged" name="father_changed" data-target="fatherFields">
-            <label class="form-check-label" for="fatherChanged">Father's Name Changed</label>
-        </div>
-        <div class="form-check">
-            <input class="form-check-input change-toggle" type="checkbox" id="motherChanged" name="mother_changed" data-target="motherFields">
-            <label class="form-check-label" for="motherChanged">Mother's Name Changed</label>
-        </div>
-        <div class="form-check">
-            <input class="form-check-input change-toggle" type="checkbox" id="dobChanged" name="dob_changed" data-target="dobFields">
-            <label class="form-check-label" for="dobChanged">Date of Birth Changed</label>
-        </div>
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-7">
+            <div class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h2 class="mb-4">Passport Change Form</h2>
 
-        <!-- Name Fields -->
-        <div id="nameFields" class="d-none mt-3">
-            <hr>
-            <h5>Name Change</h5>
-            <div class="mb-3">
-                <label class="form-label">Old Name</label>
-                <input type="text" name="old_name" class="form-control">
-            </div>
-            <div class="mb-3">
-                <label class="form-label">New Name</label>
-                <input type="text" name="new_name" class="form-control">
+                    @if($errors->any())
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form action="{{ route('passport.store') }}" method="POST">
+                        @csrf
+
+                        @include('passport.partials.form-fields')
+
+                        <div class="d-flex justify-content-end mt-4">
+                            <button type="submit" class="btn btn-primary px-4">Submit</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
-
-        <!-- Father Fields -->
-        <div id="fatherFields" class="d-none mt-3">
-            <hr>
-            <h5>Father's Name Change</h5>
-            <div class="mb-3">
-                <label class="form-label">Old Father's Name</label>
-                <input type="text" name="old_father_name" class="form-control">
-            </div>
-            <div class="mb-3">
-                <label class="form-label">New Father's Name</label>
-                <input type="text" name="new_father_name" class="form-control">
-            </div>
-        </div>
-
-        <!-- Mother Fields -->
-        <div id="motherFields" class="d-none mt-3">
-            <hr>
-            <h5>Mother's Name Change</h5>
-            <div class="mb-3">
-                <label class="form-label">Old Mother's Name</label>
-                <input type="text" name="old_mother_name" class="form-control">
-            </div>
-            <div class="mb-3">
-                <label class="form-label">New Mother's Name</label>
-                <input type="text" name="new_mother_name" class="form-control">
-            </div>
-        </div>
-
-        <!-- DOB Fields -->
-        <div id="dobFields" class="d-none mt-3">
-            <hr>
-            <h5>Date of Birth Change</h5>
-            <div class="mb-3">
-                <label class="form-label">Old Date of Birth</label>
-                <input type="date" name="old_dob" class="form-control">
-            </div>
-            <div class="mb-3">
-                <label class="form-label">New Date of Birth</label>
-                <input type="date" name="new_dob" class="form-control">
-            </div>
-        </div>
-
-        <h5>Verified By :</h5>
-
-        <div class="form-check">
-            <input class="form-check-input" type="checkbox" name="nid" id="nid">
-            <label class="form-check-label" for="nid">National Identity Card (NID)</label>
-        </div>
-
-        <div class="form-check">
-            <input class="form-check-input" type="checkbox" name="brc" id="brc">
-            <label class="form-check-label" for="brc">Birth Certificate (BRC)</label>
-        </div>
-
-        <button type="submit" class="btn btn-primary mt-3">Submit</button>
-    </form>
+    </div>
 </div>
-
-<script>
-    // Toggle visibility of each field group based on its checkbox
-    document.querySelectorAll('.change-toggle').forEach(toggle => {
-        toggle.addEventListener('change', () => {
-            const targetId = toggle.dataset.target;
-            document.getElementById(targetId).classList.toggle('d-none', !toggle.checked);
-        });
-    });
-</script>
-</body>
-</html>
+@endsection

--- a/resources/views/passport/index.blade.php
+++ b/resources/views/passport/index.blade.php
@@ -1,66 +1,70 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Passport Change Records</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container my-5">
+@extends('layouts.app')
+
+@section('title', 'Passport Change Records')
+
+@section('content')
+<div class="container">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4 gap-2">
-        <h2 class="mb-2 mb-md-0">Passport Change Records</h2>
+        <h2 class="mb-0">Passport Change Records</h2>
         <div class="d-flex flex-wrap gap-2">
             <a href="{{ route('passport.create') }}" class="btn btn-primary">
-                <i class="bi bi-plus-lg"></i> Add New
+                <i class="bi bi-plus-lg me-2"></i> Add New
             </a>
             <a href="{{ route('signature.edit') }}" class="btn btn-outline-secondary">
-                <i class="bi bi-pencil-square"></i> Update Certificate Signature
+                <i class="bi bi-pencil-square me-2"></i> Update Certificate Signature
             </a>
         </div>
     </div>
 
-
-@if(session('success'))
-        <div class="alert alert-success">{{ session('success') }}</div>
+    @if(session('success'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
     @endif
 
-    <table class="table table-bordered table-striped">
-        <thead>
-        <tr>
-            <th>#</th>
-            <th>Serial</th>
-            <th>Date</th>
-            <th>Old Passport No</th>
-            <th>New Passport No</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        @forelse($records as $record)
+    <div class="table-responsive shadow-sm">
+        <table class="table table-bordered table-striped align-middle mb-0">
+            <thead class="table-light">
             <tr>
-                <td>{{ $loop->iteration }}</td>
-                <td>{{ $record->serial }}</td>
-                <td>{{ $record->date }}</td>
-                <td>{{ $record->old_passport_number }}</td>
-                <td>{{ $record->new_passport_number }}</td>
-                <td>
-                    <a href="{{ route('passport.show', $record->id) }}" class="btn btn-sm btn-info">Details</a>
-                    <a href="{{ route('passport.edit', $record->id) }}" class="btn btn-sm btn-warning">Edit</a>
+                <th scope="col" style="width: 60px;">#</th>
+                <th scope="col">Serial</th>
+                <th scope="col">Date</th>
+                <th scope="col">Old Passport No</th>
+                <th scope="col">New Passport No</th>
+                <th scope="col" class="text-center" style="width: 200px;">Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            @forelse($records as $record)
+                <tr>
+                    <td>{{ $loop->iteration }}</td>
+                    <td>{{ $record->serial }}</td>
+                    <td>{{ $record->date }}</td>
+                    <td>{{ $record->old_passport_number }}</td>
+                    <td>{{ $record->new_passport_number }}</td>
+                    <td class="text-center">
+                        <div class="d-flex justify-content-center gap-2">
+                            <a href="{{ route('passport.show', $record->id) }}" class="btn btn-sm btn-info text-white">
+                                Details
+                            </a>
+                            <a href="{{ route('passport.edit', $record->id) }}" class="btn btn-sm btn-warning text-white">
+                                Edit
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="6" class="text-center py-4">No records found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
 
-                </td>
-            </tr>
-        @empty
-            <tr>
-                <td colspan="6" class="text-center">No records found.</td>
-            </tr>
-        @endforelse
-        </tbody>
-    </table>
-    <!-- Pagination links -->
-    <div class="d-flex justify-content-center">
+    <div class="d-flex justify-content-center mt-4">
         {{ $records->links('pagination::bootstrap-5') }}
     </div>
 </div>
-</body>
-</html>
+@endsection

--- a/resources/views/passport/partials/form-fields.blade.php
+++ b/resources/views/passport/partials/form-fields.blade.php
@@ -1,0 +1,176 @@
+@php
+    $model = $passportChange ?? null;
+
+    $value = function (string $field, ?string $format = null) use ($model) {
+        $oldValue = old($field);
+        if (!is_null($oldValue)) {
+            return $oldValue;
+        }
+
+        $current = $model?->{$field} ?? null;
+
+        if ($format && $current) {
+            try {
+                if ($current instanceof \Illuminate\Support\Carbon) {
+                    return $current->format($format);
+                }
+
+                return \Illuminate\Support\Carbon::parse($current)->format($format);
+            } catch (\Throwable $exception) {
+                return $current;
+            }
+        }
+
+        return $current ?? '';
+    };
+
+    $checked = function (string $field) use ($model) {
+        $oldValue = old($field);
+        if (!is_null($oldValue)) {
+            return filter_var($oldValue, FILTER_VALIDATE_BOOL);
+        }
+
+        return (bool) ($model?->{$field} ?? false);
+    };
+
+    $nameFieldsVisible = $checked('name_changed');
+    $fatherFieldsVisible = $checked('father_changed');
+    $motherFieldsVisible = $checked('mother_changed');
+    $dobFieldsVisible = $checked('dob_changed');
+@endphp
+
+<div class="mb-3">
+    <label for="serial" class="form-label">Serial</label>
+    <input type="text" id="serial" name="serial" class="form-control" value="{{ $value('serial') }}">
+</div>
+
+<div class="mb-3">
+    <label for="date" class="form-label">Date</label>
+    <input type="date" id="date" name="date" class="form-control" value="{{ $value('date', 'Y-m-d') }}">
+</div>
+
+<div class="mb-3">
+    <label for="name" class="form-label">Name</label>
+    <input type="text" id="name" name="name" class="form-control" value="{{ $value('name') }}">
+</div>
+
+<h5 class="mt-4">Passport Numbers</h5>
+
+<div class="mb-3">
+    <label for="old_passport_number" class="form-label">Old Passport Number</label>
+    <input type="text" id="old_passport_number" name="old_passport_number" class="form-control" value="{{ $value('old_passport_number') }}">
+</div>
+
+<div class="mb-3">
+    <label for="new_passport_number" class="form-label">New Passport Number</label>
+    <input type="text" id="new_passport_number" name="new_passport_number" class="form-control" value="{{ $value('new_passport_number') }}">
+</div>
+
+<div class="mb-3">
+    <label for="new_passport_issue_date" class="form-label">New Passport Issue Date</label>
+    <input type="date" id="new_passport_issue_date" name="new_passport_issue_date" class="form-control" value="{{ $value('new_passport_issue_date', 'Y-m-d') }}">
+</div>
+
+<h5 class="mt-4">Changes</h5>
+
+<div class="form-check">
+    <input class="form-check-input change-toggle" type="checkbox" id="name_changed" name="name_changed" data-target="nameFields" @checked($nameFieldsVisible)>
+    <label class="form-check-label" for="name_changed">Name Changed</label>
+</div>
+<div id="nameFields" class="mt-3 {{ $nameFieldsVisible ? '' : 'd-none' }}">
+    <hr>
+    <h5>Name Change</h5>
+    <div class="mb-3">
+        <label for="old_name" class="form-label">Old Name</label>
+        <input type="text" id="old_name" name="old_name" class="form-control" value="{{ $value('old_name') }}">
+    </div>
+    <div class="mb-3">
+        <label for="new_name" class="form-label">New Name</label>
+        <input type="text" id="new_name" name="new_name" class="form-control" value="{{ $value('new_name') }}">
+    </div>
+</div>
+
+<div class="form-check">
+    <input class="form-check-input change-toggle" type="checkbox" id="father_changed" name="father_changed" data-target="fatherFields" @checked($fatherFieldsVisible)>
+    <label class="form-check-label" for="father_changed">Father's Name Changed</label>
+</div>
+<div id="fatherFields" class="mt-3 {{ $fatherFieldsVisible ? '' : 'd-none' }}">
+    <hr>
+    <h5>Father's Name Change</h5>
+    <div class="mb-3">
+        <label for="old_father_name" class="form-label">Old Father's Name</label>
+        <input type="text" id="old_father_name" name="old_father_name" class="form-control" value="{{ $value('old_father_name') }}">
+    </div>
+    <div class="mb-3">
+        <label for="new_father_name" class="form-label">New Father's Name</label>
+        <input type="text" id="new_father_name" name="new_father_name" class="form-control" value="{{ $value('new_father_name') }}">
+    </div>
+</div>
+
+<div class="form-check">
+    <input class="form-check-input change-toggle" type="checkbox" id="mother_changed" name="mother_changed" data-target="motherFields" @checked($motherFieldsVisible)>
+    <label class="form-check-label" for="mother_changed">Mother's Name Changed</label>
+</div>
+<div id="motherFields" class="mt-3 {{ $motherFieldsVisible ? '' : 'd-none' }}">
+    <hr>
+    <h5>Mother's Name Change</h5>
+    <div class="mb-3">
+        <label for="old_mother_name" class="form-label">Old Mother's Name</label>
+        <input type="text" id="old_mother_name" name="old_mother_name" class="form-control" value="{{ $value('old_mother_name') }}">
+    </div>
+    <div class="mb-3">
+        <label for="new_mother_name" class="form-label">New Mother's Name</label>
+        <input type="text" id="new_mother_name" name="new_mother_name" class="form-control" value="{{ $value('new_mother_name') }}">
+    </div>
+</div>
+
+<div class="form-check">
+    <input class="form-check-input change-toggle" type="checkbox" id="dob_changed" name="dob_changed" data-target="dobFields" @checked($dobFieldsVisible)>
+    <label class="form-check-label" for="dob_changed">Date of Birth Changed</label>
+</div>
+<div id="dobFields" class="mt-3 {{ $dobFieldsVisible ? '' : 'd-none' }}">
+    <hr>
+    <h5>Date of Birth Change</h5>
+    <div class="mb-3">
+        <label for="old_dob" class="form-label">Old Date of Birth</label>
+        <input type="date" id="old_dob" name="old_dob" class="form-control" value="{{ $value('old_dob', 'Y-m-d') }}">
+    </div>
+    <div class="mb-3">
+        <label for="new_dob" class="form-label">New Date of Birth</label>
+        <input type="date" id="new_dob" name="new_dob" class="form-control" value="{{ $value('new_dob', 'Y-m-d') }}">
+    </div>
+</div>
+
+<h5 class="mt-4">Verified By</h5>
+<div class="form-check">
+    <input class="form-check-input" type="checkbox" id="nid" name="nid" @checked($checked('nid'))>
+    <label class="form-check-label" for="nid">National Identity Card (NID)</label>
+</div>
+<div class="form-check">
+    <input class="form-check-input" type="checkbox" id="brc" name="brc" @checked($checked('brc'))>
+    <label class="form-check-label" for="brc">Birth Certificate (BRC)</label>
+</div>
+
+@once
+    @push('scripts')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                document.querySelectorAll('.change-toggle').forEach(function (toggle) {
+                    var targetId = toggle.dataset.target;
+                    var target = document.getElementById(targetId);
+
+                    if (!target) {
+                        return;
+                    }
+
+                    var toggleSection = function () {
+                        target.classList.toggle('d-none', !toggle.checked);
+                    };
+
+                    toggle.addEventListener('change', toggleSection);
+                    toggleSection();
+                });
+            });
+        </script>
+    @endpush
+@endonce

--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -1,7 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
+@extends('layouts.pdf')
+
+@section('title', 'Passport Change Summary')
+
+@push('styles')
     <style>
         body {
             font-family: "Times New Roman", Times, serif;
@@ -16,7 +17,6 @@
             font-style: italic;
             color: #1c6b13;
             font-weight: bold;
-
         }
 
         .header h5 {
@@ -29,13 +29,6 @@
             text-align: center;
             font-size: 12pt;
             margin-top: 0;
-        }
-
-        .ref-date {
-            display: flex;
-            justify-content: space-between;
-            margin: 20px 0;
-            font-size: 12pt;
         }
 
         .content {
@@ -59,21 +52,20 @@
             text-align: center;
             border-top: 1px solid #1c6b13;
             padding-top: 5px;
-            color:#1c6b13 ;
+            color: #1c6b13;
             font-style: italic;
         }
     </style>
-</head>
-<body>
+@endpush
 
-<!-- Header -->
+@section('content')
 <div class="header">
     <img src="{{ public_path('images/logo.png') }}" alt="Logo" style="height: 80px;">
     <h5 style="margin: 0px 80px 0px 80px">High Commission of the People’s Republic of Bangladesh</h5>
     <div class="sub-header">Brunei Darussalam</div>
 </div>
 <hr style="color:#1c6b13;width: 100%">
-<!-- Reference and Date -->
+
 <table width="100%" style="margin: 20px 0; font-size: 12pt;">
     <tr>
         <td style="text-align: left;">
@@ -85,21 +77,16 @@
     </tr>
 </table>
 
-
-<!-- Main Paragraph -->
 <div class="content">
-    <p>
     @php
         $text = "This is to certify that ";
 
-        // Name (just display, don't bold)
         if ($passportChange->new_name) {
             $text .= "{$passportChange->new_name} ";
         } else {
             $text .= "this person ";
         }
 
-        // Passport number and issue date (normal, not bold)
         if ($passportChange->new_passport_number) {
             $text .= "bearing Bangladesh passport no. {$passportChange->new_passport_number}";
             if ($passportChange->new_passport_issue_date) {
@@ -110,12 +97,10 @@
 
         $text .= "is a Bangladeshi citizen working in Brunei Darussalam. ";
 
-        // Old passport
         if ($passportChange->old_passport_number) {
             $text .= "In his old passport no. {$passportChange->old_passport_number}, ";
         }
 
-        // Only bold changed info (name, father, mother, DOB)
         $oldParts = [];
         $newParts = [];
 
@@ -141,7 +126,6 @@
             $text .= implode(', ', $newParts) . " as mentioned in ";
         }
 
-        // NID and BRC (normal text)
         if ($passportChange->nid && $passportChange->brc) {
             $text .= "his National Identity Card (NID) and Birth Certificate (BRC) issued by the competent authority in Bangladesh.";
         } elseif ($passportChange->nid) {
@@ -151,34 +135,25 @@
         }
     @endphp
 
-    <p class="text-justify">{!! $text !!}</p>
+    <p>{!! $text !!}</p>
 
     <p>02. All concerned are requested to kindly extend necessary cooperation.</p>
-
 </div>
 
-<!-- Signature -->
 <table width="100%" style="margin-top: 50px; font-size: 12pt;">
     <tr>
-        <!-- Wide empty column -->
         <td style="width: 60%;"></td>
-
-        <!-- Signature column -->
         <td style="width: 40%; text-align: center;">
             <div class="signature">
-                <p> {{ ($signature->name) }}</p>
+                <p>{{ $signature->name }}</p>
                 <p>{{ $signature->designation }}</p>
             </div>
         </td>
     </tr>
 </table>
 
-
-<!-- Footer -->
 <footer>
     Lot No. 2469, Simpang-1028, Kampong Tanah Jambu, Jalan Muara, Bandar Seri Begawan, Negara Brunei Darussalam.
     Tel: 673-2342420 Fax: 673-2342421, Web: mission.bandarseribegawan@mofa.gov.bd
 </footer>
-
-</body>
-</html>
+@endsection

--- a/resources/views/passport/summary.blade.php
+++ b/resources/views/passport/summary.blade.php
@@ -1,31 +1,39 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+@extends('layouts.app')
+
+@section('title', 'Passport Change Summary')
+@section('body-class', 'document-page')
+
+@push('styles')
     <style>
-        body {
+        body.document-page {
             font-family: "Times New Roman", Times, serif;
             font-size: 12pt;
             background-color: #f8f9fa;
         }
+
         .document-card {
             background: #fff;
             padding: 40px;
             border-radius: 12px;
-            box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+            max-width: 900px;
+            margin: 0 auto;
         }
-        .logo {
+
+        .document-card .logo {
             height: 80px;
         }
-    </style>
-</head>
-<body>
 
+        .document-footer {
+            border-top: 1px solid #198754;
+            color: #198754;
+        }
+    </style>
+@endpush
+
+@section('content')
 <div class="container my-5">
     <div class="document-card">
-
-        <!-- Header -->
         <div class="text-center mb-3">
             <img src="{{ asset('images/logo.png') }}" alt="Logo" class="logo mb-2">
             <h4 class="fw-bold text-success mb-0">High Commission of the People’s Republic of Bangladesh</h4>
@@ -33,25 +41,21 @@
         </div>
         <hr class="border-2 border-success opacity-75">
 
-        <!-- Reference and Date -->
         <div class="d-flex justify-content-between my-3">
             <div><strong>No.</strong> BHC/Bru/Cons/CA/{{ date('Y') }}/{{ $passportChange->serial ?? '___' }}</div>
             <div><strong>Date:</strong> {{ \Carbon\Carbon::parse($passportChange->date ?? now())->format('d F Y') }}</div>
         </div>
 
-        <!-- Main Paragraph -->
         <div class="mt-4">
             @php
                 $text = "This is to certify that ";
 
-                // Name (just display, don't bold)
                 if ($passportChange->new_name) {
                     $text .= "{$passportChange->new_name} ";
                 } else {
                     $text .= "this person ";
                 }
 
-                // Passport number and issue date (normal, not bold)
                 if ($passportChange->new_passport_number) {
                     $text .= "bearing Bangladesh passport no. {$passportChange->new_passport_number}";
                     if ($passportChange->new_passport_issue_date) {
@@ -62,12 +66,10 @@
 
                 $text .= "is a Bangladeshi citizen working in Brunei Darussalam. ";
 
-                // Old passport
                 if ($passportChange->old_passport_number) {
                     $text .= "In his old passport no. {$passportChange->old_passport_number}, ";
                 }
 
-                // Only bold changed info (name, father, mother, DOB)
                 $oldParts = [];
                 $newParts = [];
 
@@ -93,7 +95,6 @@
                     $text .= implode(', ', $newParts) . " as mentioned in ";
                 }
 
-                // NID and BRC (normal text)
                 if ($passportChange->nid && $passportChange->brc) {
                     $text .= "his National Identity Card (NID) and Birth Certificate (BRC) issued by the competent authority in Bangladesh.";
                 } elseif ($passportChange->nid) {
@@ -106,43 +107,26 @@
             <p class="text-justify">{!! $text !!}</p>
 
             <p>02. All concerned are requested to kindly extend necessary cooperation.</p>
-
         </div>
 
-        <!-- Signature -->
         <div class="row mt-5">
             <div class="col-7"></div>
             <div class="col-5 text-center">
                 <p class="fw-bold mb-0">( {{ $signature->name }} )</p>
-                <p class="mb-0">{{ $signature->designation}}</p>
+                <p class="mb-0">{{ $signature->designation }}</p>
             </div>
         </div>
 
-        <!-- Action Buttons -->
         <div class="d-flex justify-content-center gap-3 mt-4">
             <a href="{{ route('passport.index') }}" class="btn btn-outline-secondary px-4 rounded-pill shadow-sm">⬅ Back</a>
-            <!-- Download Button -->
-            <a href="{{ route('passport.print', $passportChange->id) }}?download=1"
-               class="btn btn-success px-4 rounded-pill shadow-sm">
-                📄 Download PDF
-            </a>
-
-            <!-- Print Button -->
-            <a href="{{ route('passport.print', $passportChange->id) }}"
-               target="_blank"
-               class="btn btn-primary px-4 rounded-pill shadow-sm">
-                🖨 Print PDF
-            </a>
+            <a href="{{ route('passport.print', $passportChange->id) }}?download=1" class="btn btn-success px-4 rounded-pill shadow-sm">📄 Download PDF</a>
+            <a href="{{ route('passport.print', $passportChange->id) }}" target="_blank" class="btn btn-primary px-4 rounded-pill shadow-sm">🖨 Print PDF</a>
         </div>
-
     </div>
 
-    <!-- Footer -->
-    <footer class="text-center border-top border-success pt-3 mt-5 fst-italic text-success small">
+    <footer class="text-center document-footer pt-3 mt-5 fst-italic small">
         Lot No. 2469, Simpang-1028, Kampong Tanah Jambu, Jalan Muara, Bandar Seri Begawan, Negara Brunei Darussalam.
         Tel: 673-2342420 Fax: 673-2342421 | Email: mission.bandarseribegawan@mofa.gov.bd
     </footer>
 </div>
-
-</body>
-</html>
+@endsection

--- a/resources/views/signature/edit.blade.php
+++ b/resources/views/signature/edit.blade.php
@@ -1,51 +1,52 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Edit Signature</title>
-    <!-- Bootstrap 5 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<div class="container mt-5">
-    <h1 class="mb-4">Edit Signature</h1>
+@extends('layouts.app')
 
-    <!-- Success Message -->
-    @if(session('success'))
-        <div class="alert alert-success">{{ session('success') }}</div>
-    @endif
+@section('title', 'Edit Signature')
 
-    <!-- Validation Errors -->
-    @if($errors->any())
-        <div class="alert alert-danger">
-            <ul class="mb-0">
-                @foreach($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-6 col-xl-5">
+            <div class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h1 class="h3 mb-4">Edit Signature</h1>
+
+                    @if(session('success'))
+                        <div class="alert alert-success alert-dismissible fade show" role="alert">
+                            {{ session('success') }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                        </div>
+                    @endif
+
+                    @if($errors->any())
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form action="{{ route('signature.update', $signature->id) }}" method="POST">
+                        @csrf
+
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Name</label>
+                            <input type="text" name="name" id="name" class="form-control" value="{{ old('name', $signature->name) }}">
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="designation" class="form-label">Designation</label>
+                            <input type="text" name="designation" id="designation" class="form-control" value="{{ old('designation', $signature->designation) }}">
+                        </div>
+
+                        <div class="d-flex justify-content-end">
+                            <button type="submit" class="btn btn-primary px-4">Update Signature</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-    @endif
-
-    <form action="{{ route('signature.update', $signature->id) }}" method="POST">
-        @csrf
-        @method('POST')
-
-        <div class="mb-3">
-            <label for="name" class="form-label">Name</label>
-            <input type="text" name="name" id="name" class="form-control" value="{{ old('name', $signature->name) }}">
-        </div>
-
-        <div class="mb-3">
-            <label for="designation" class="form-label">Designation</label>
-            <input type="text" name="designation" id="designation" class="form-control" value="{{ old('designation', $signature->designation) }}">
-        </div>
-
-        <button type="submit" class="btn btn-primary">Update Signature</button>
-    </form>
+    </div>
 </div>
-
-<!-- Bootstrap 5 JS (optional) -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+@endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,18 +1,14 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Passport Change Management</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+@extends('layouts.app')
+
+@section('title', 'Passport Change Management')
+@section('body-class', 'welcome-page')
+@section('main-class', 'p-0')
+
+@push('styles')
     <style>
-        body, html {
-            height: 100%;
-            margin: 0;
-            font-family: "Times New Roman", Times, serif;
-        }
-        .hero {
-            height: 100vh;
-            background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
+        .welcome-hero {
+            min-height: 100vh;
+            background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)),
             url('{{ asset('images/bg.jpg') }}') no-repeat center center/cover;
             color: white;
             display: flex;
@@ -20,48 +16,52 @@
             justify-content: center;
             text-align: center;
         }
-        .hero-card {
+
+        .welcome-card {
             background: rgba(255, 255, 255, 0.9);
             padding: 40px;
             border-radius: 15px;
             color: #212529;
-            box-shadow: 0 8px 25px rgba(0,0,0,0.2);
+            box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+            max-width: 540px;
         }
-        .hero-card img {
+
+        .welcome-card img {
             height: 90px;
             margin-bottom: 15px;
         }
-        .hero-card h1 {
+
+        .welcome-card h1 {
             font-weight: bold;
             color: #1c6b13;
         }
-        .hero-card p {
+
+        .welcome-card p {
             font-size: 14pt;
             margin-bottom: 25px;
         }
+
         .btn-custom {
             border-radius: 50px;
             padding: 10px 30px;
             font-size: 14pt;
         }
     </style>
-</head>
-<body>
+@endpush
 
-<div class="hero">
-    <div class="hero-card">
+@section('content')
+<div class="welcome-hero">
+    <div class="welcome-card">
         <img src="{{ asset('images/logo.png') }}" alt="Logo">
         <h1>Welcome to Passport Change Management</h1>
-        <p class="lead">
+        <p class="lead mb-4">
             High Commission of the People’s Republic of Bangladesh <br>
             Brunei Darussalam
         </p>
-        <div class="d-flex justify-content-center gap-3">
+        <div class="d-flex justify-content-center gap-3 flex-wrap">
             <a href="{{ route('passport.create') }}" class="btn btn-success btn-custom shadow">➕ Add New Record</a>
             <a href="{{ route('passport.index') }}" class="btn btn-primary btn-custom shadow">📂 View Records</a>
         </div>
     </div>
 </div>
-
-</body>
-</html>
+@endsection


### PR DESCRIPTION
## Summary
- add shared application and PDF Blade layouts plus a reusable passport form partial to remove duplicated markup
- update passport CRUD, summary, and welcome views to extend the new layout, include validation feedback, and preserve existing behaviors
- restyle the signature editor and summary pages with consistent Bootstrap-based structure and alerts

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b8c83f608326b52cce34de7aa4d6