### PR TITLE
Fix grammar for singular/plural passport summary sentences

### DIFF
--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -121,8 +121,11 @@
             $newParts[] = "his actual date of birth is <strong>" . \Carbon\Carbon::parse($passportChange->new_dob)->format('d F Y') . "</strong>";
         }
 
-        if (count($oldParts) > 0) {
-            $text .= implode(', ', $oldParts) . ", which are not correct. ";
+        $changeCount = count($oldParts);
+
+        if ($changeCount > 0) {
+            $text .= implode(', ', $oldParts);
+            $text .= $changeCount > 1 ? ", which are not correct. " : ", which is not correct. ";
             $text .= implode(', ', $newParts) . " as mentioned in ";
         }
 

--- a/resources/views/passport/summary.blade.php
+++ b/resources/views/passport/summary.blade.php
@@ -90,8 +90,11 @@
                     $newParts[] = "his actual date of birth is <strong>" . \Carbon\Carbon::parse($passportChange->new_dob)->format('d F Y') . "</strong>";
                 }
 
-                if (count($oldParts) > 0) {
-                    $text .= implode(', ', $oldParts) . ", which are not correct. ";
+                $changeCount = count($oldParts);
+
+                if ($changeCount > 0) {
+                    $text .= implode(', ', $oldParts);
+                    $text .= $changeCount > 1 ? ", which are not correct. " : ", which is not correct. ";
                     $text .= implode(', ', $newParts) . " as mentioned in ";
                 }
 


### PR DESCRIPTION
## Summary
- adjust the summary view text builder to use singular or plural phrasing based on the number of corrections being described
- mirror the dynamic grammar fix in the printable summary template

## Testing
- php artisan test *(fails: vendor/autoload.php missing because Composer dependencies are unavailable in the environment)*
- composer install *(fails: GitHub returned 403 when attempting to download packages without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c6593bd88326b9f1c6bc74098575