### PR TITLE
Add consistent date picker support and date normalization

### DIFF
--- a/app/Models/PassportChange.php
+++ b/app/Models/PassportChange.php
@@ -33,12 +33,15 @@ class PassportChange extends Model
     ];
 
     protected $casts = [
+        'date' => 'date',
         'name_changed' => 'boolean',
         'father_changed' => 'boolean',
         'mother_changed' => 'boolean',
         'dob_changed' => 'boolean',
         'nid' => 'boolean',  // ✅ Cast as boolean
         'brc' => 'boolean',  // ✅ Cast as boolean
+        'old_dob' => 'date',
+        'new_dob' => 'date',
         'new_passport_issue_date' => 'date',  // ✅ Cast properly
 
     ];

--- a/resources/views/passport/index.blade.php
+++ b/resources/views/passport/index.blade.php
@@ -40,7 +40,7 @@
                 <tr>
                     <td>{{ $loop->iteration }}</td>
                     <td>{{ $record->serial }}</td>
-                    <td>{{ $record->date }}</td>
+                    <td>{{ $record->date?->format('d-m-Y') }}</td>
                     <td>{{ $record->old_passport_number }}</td>
                     <td>{{ $record->new_passport_number }}</td>
                     <td class="text-center">

--- a/resources/views/passport/partials/form-fields.blade.php
+++ b/resources/views/passport/partials/form-fields.blade.php
@@ -46,7 +46,16 @@
 
 <div class="mb-3">
     <label for="date" class="form-label">Date</label>
-    <input type="date" id="date" name="date" class="form-control" value="{{ $value('date', 'Y-m-d') }}">
+    <input
+        type="text"
+        id="date"
+        name="date"
+        class="form-control date-picker"
+        placeholder="DD-MM-YYYY"
+        inputmode="numeric"
+        pattern="\d{2}-\d{2}-\d{4}"
+        value="{{ $value('date', 'd-m-Y') }}"
+    >
 </div>
 
 <div class="mb-3">
@@ -68,7 +77,16 @@
 
 <div class="mb-3">
     <label for="new_passport_issue_date" class="form-label">New Passport Issue Date</label>
-    <input type="date" id="new_passport_issue_date" name="new_passport_issue_date" class="form-control" value="{{ $value('new_passport_issue_date', 'Y-m-d') }}">
+    <input
+        type="text"
+        id="new_passport_issue_date"
+        name="new_passport_issue_date"
+        class="form-control date-picker"
+        placeholder="DD-MM-YYYY"
+        inputmode="numeric"
+        pattern="\d{2}-\d{2}-\d{4}"
+        value="{{ $value('new_passport_issue_date', 'd-m-Y') }}"
+    >
 </div>
 
 <h5 class="mt-4">Changes</h5>
@@ -133,11 +151,29 @@
     <h5>Date of Birth Change</h5>
     <div class="mb-3">
         <label for="old_dob" class="form-label">Old Date of Birth</label>
-        <input type="date" id="old_dob" name="old_dob" class="form-control" value="{{ $value('old_dob', 'Y-m-d') }}">
+        <input
+            type="text"
+            id="old_dob"
+            name="old_dob"
+            class="form-control date-picker"
+            placeholder="DD-MM-YYYY"
+            inputmode="numeric"
+            pattern="\d{2}-\d{2}-\d{4}"
+            value="{{ $value('old_dob', 'd-m-Y') }}"
+        >
     </div>
     <div class="mb-3">
         <label for="new_dob" class="form-label">New Date of Birth</label>
-        <input type="date" id="new_dob" name="new_dob" class="form-control" value="{{ $value('new_dob', 'Y-m-d') }}">
+        <input
+            type="text"
+            id="new_dob"
+            name="new_dob"
+            class="form-control date-picker"
+            placeholder="DD-MM-YYYY"
+            inputmode="numeric"
+            pattern="\d{2}-\d{2}-\d{4}"
+            value="{{ $value('new_dob', 'd-m-Y') }}"
+        >
     </div>
 </div>
 
@@ -152,7 +188,12 @@
 </div>
 
 @once
+    @push('styles')
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    @endpush
+
     @push('scripts')
+        <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
         <script>
             document.addEventListener('DOMContentLoaded', function () {
                 document.querySelectorAll('.change-toggle').forEach(function (toggle) {
@@ -170,6 +211,17 @@
                     toggle.addEventListener('change', toggleSection);
                     toggleSection();
                 });
+
+                if (window.flatpickr) {
+                    document.querySelectorAll('.date-picker').forEach(function (input) {
+                        window.flatpickr(input, {
+                            dateFormat: 'd-m-Y',
+                            allowInput: true,
+                            altInput: false,
+                            defaultDate: input.value || null,
+                        });
+                    });
+                }
             });
         </script>
     @endpush


### PR DESCRIPTION
## Summary
- replace the date inputs in the shared passport form partial with Flatpickr-powered pickers that use a DD-MM-YYYY format for both the create and edit screens
- ensure list pages also present dates in the same format and load the Flatpickr assets once
- normalise submitted dates to database-friendly values and cast date attributes on the PassportChange model for consistent access in the UI

## Testing
- `php artisan test` *(fails: missing vendor directory prior to installing dependencies)*
- `composer install` *(fails: unable to download GitHub-hosted packages without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cc5ef63083269e10783d21208dcc