### PR TITLE
Align signature section with date in summary views

### DIFF
--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -35,12 +35,35 @@
             text-align: justify;
         }
 
-        .signature {
-            margin-top: 60px;
+        .signature-table {
+            width: 100%;
+            margin-top: 50px;
+            font-size: 12pt;
         }
 
-        .signature p {
-            margin: 0;
+        .signature-table td:first-child {
+            width: 55%;
+        }
+
+        .signature-table td:last-child {
+            width: 45%;
+        }
+
+        .signature-cell {
+            text-align: right;
+        }
+
+        .signature-wrapper {
+            display: inline-block;
+            min-width: 45%;
+            margin-top: 60px;
+            text-align: right;
+        }
+
+        .signature-text {
+            display: inline-block;
+            white-space: nowrap;
+            font-weight: bold;
         }
 
         footer {
@@ -172,13 +195,20 @@
     <p>02. All concerned are requested to kindly extend necessary cooperation.</p>
 </div>
 
-<table width="100%" style="margin-top: 50px; font-size: 12pt;">
+@php
+    $signatureLine = implode(', ', array_filter([
+        $signature->name ?? null,
+        $signature->designation ?? null,
+    ], static fn ($value) => filled($value)));
+    $signatureDisplay = $signatureLine !== '' ? '( ' . $signatureLine . ' )' : "\u{00A0}";
+@endphp
+
+<table class="signature-table">
     <tr>
-        <td style="width: 60%;"></td>
-        <td style="width: 40%; text-align: center;">
-            <div class="signature">
-                <p>{{ $signature->name }}</p>
-                <p>{{ $signature->designation }}</p>
+        <td></td>
+        <td class="signature-cell">
+            <div class="signature-wrapper">
+                <span class="signature-text">{{ $signatureDisplay }}</span>
             </div>
         </td>
     </tr>

--- a/resources/views/passport/summary.blade.php
+++ b/resources/views/passport/summary.blade.php
@@ -28,6 +28,17 @@
             border-top: 1px solid #198754;
             color: #198754;
         }
+
+        .signature-block {
+            margin-left: auto;
+            min-width: 45%;
+            text-align: right;
+        }
+
+        .signature-block span {
+            display: inline-block;
+            white-space: nowrap;
+        }
     </style>
 @endpush
 
@@ -141,11 +152,17 @@
             <p>02. All concerned are requested to kindly extend necessary cooperation.</p>
         </div>
 
-        <div class="row mt-5">
-            <div class="col-7"></div>
-            <div class="col-5 text-center">
-                <p class="fw-bold mb-0">( {{ $signature->name }} )</p>
-                <p class="mb-0">{{ $signature->designation }}</p>
+        @php
+            $signatureLine = implode(', ', array_filter([
+                $signature->name ?? null,
+                $signature->designation ?? null,
+            ], static fn ($value) => filled($value)));
+            $signatureDisplay = $signatureLine !== '' ? '( ' . $signatureLine . ' )' : "\u{00A0}";
+        @endphp
+
+        <div class="d-flex justify-content-end mt-5">
+            <div class="signature-block">
+                <span class="fw-bold">{{ $signatureDisplay }}</span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- align the signature section in the web summary so its width matches the header date and the name/designation render on one line
- mirror the signature formatting changes in the printable summary with wider right-column width and single-line signature text

## Testing
- php artisan test *(fails: vendor/autoload.php missing; composer install requires a GitHub token and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d2c8855c832698127eda204d8245