### PR TITLE
Separate signature details in summary views

### DIFF
--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -61,9 +61,16 @@
         }
 
         .signature-text {
-            display: inline-block;
+            display: inline-flex;
+            flex-direction: column;
+            align-items: center;
             white-space: nowrap;
             font-weight: bold;
+        }
+
+        .signature-name,
+        .signature-designation {
+            display: block;
         }
 
         footer {
@@ -196,11 +203,8 @@
 </div>
 
 @php
-    $signatureLine = implode(', ', array_filter([
-        $signature->name ?? null,
-        $signature->designation ?? null,
-    ], static fn ($value) => filled($value)));
-    $signatureDisplay = $signatureLine !== '' ? '( ' . $signatureLine . ' )' : "\u{00A0}";
+    $signatureName = filled($signature->name ?? null) ? trim($signature->name) : null;
+    $signatureDesignation = filled($signature->designation ?? null) ? trim($signature->designation) : null;
 @endphp
 
 <table class="signature-table">
@@ -208,7 +212,17 @@
         <td></td>
         <td class="signature-cell">
             <div class="signature-wrapper">
-                <span class="signature-text">{{ $signatureDisplay }}</span>
+                <span class="signature-text">
+                    @if ($signatureName)
+                        <span class="signature-name">{{ $signatureName }}</span>
+                    @endif
+                    @if ($signatureDesignation)
+                        <span class="signature-designation">{{ $signatureDesignation }}</span>
+                    @endif
+                    @unless ($signatureName || $signatureDesignation)
+                        &nbsp;
+                    @endunless
+                </span>
             </div>
         </td>
     </tr>

--- a/resources/views/passport/summary.blade.php
+++ b/resources/views/passport/summary.blade.php
@@ -35,9 +35,16 @@
             text-align: right;
         }
 
-        .signature-block span {
-            display: inline-block;
+        .signature-text {
+            display: inline-flex;
+            flex-direction: column;
+            align-items: center;
             white-space: nowrap;
+        }
+
+        .signature-name,
+        .signature-designation {
+            display: block;
         }
     </style>
 @endpush
@@ -152,17 +159,23 @@
             <p>02. All concerned are requested to kindly extend necessary cooperation.</p>
         </div>
 
-        @php
-            $signatureLine = implode(', ', array_filter([
-                $signature->name ?? null,
-                $signature->designation ?? null,
-            ], static fn ($value) => filled($value)));
-            $signatureDisplay = $signatureLine !== '' ? '( ' . $signatureLine . ' )' : "\u{00A0}";
-        @endphp
-
         <div class="d-flex justify-content-end mt-5">
+            @php
+                $signatureName = filled($signature->name ?? null) ? trim($signature->name) : null;
+                $signatureDesignation = filled($signature->designation ?? null) ? trim($signature->designation) : null;
+            @endphp
             <div class="signature-block">
-                <span class="fw-bold">{{ $signatureDisplay }}</span>
+                <span class="signature-text fw-bold">
+                    @if ($signatureName)
+                        <span class="signature-name">{{ $signatureName }}</span>
+                    @endif
+                    @if ($signatureDesignation)
+                        <span class="signature-designation">{{ $signatureDesignation }}</span>
+                    @endif
+                    @unless ($signatureName || $signatureDesignation)
+                        &nbsp;
+                    @endunless
+                </span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- split the signature name and designation onto separate lines in the summary view
- apply the same two-line signature layout to the printable summary and center the designation beneath the name

## Testing
- phpunit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d7d09ecc8326b5bbe3f8c471ea3f