### PR TITLE
Fix signature designation alignment in print summary

### DIFF
--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -61,9 +61,8 @@
         }
 
         .signature-text {
-            display: inline-flex;
-            flex-direction: column;
-            align-items: center;
+            display: inline-block;
+            text-align: center;
             white-space: nowrap;
             font-weight: bold;
         }


### PR DESCRIPTION
## Summary
- adjust the signature block styling in the passport print summary so the designation aligns centered beneath the name

## Testing
- ⚠️ `php artisan test` *(fails: vendor/autoload.php is missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8da819af08326ba8c45ca8e1f0870