### PR TITLE
Ensure PDF summary divider spans full width

### DIFF
--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -31,6 +31,12 @@
             margin-top: 0;
         }
 
+        .page-width-divider {
+            border: none;
+            border-top: 1px solid #1c6b13;
+            margin: 0 -2cm 20px;
+        }
+
         .content {
             text-align: justify;
         }
@@ -93,7 +99,7 @@
     <h5 style="margin: 0px 80px 0px 80px">High Commission of the People’s Republic of Bangladesh</h5>
     <div class="sub-header">Brunei Darussalam</div>
 </div>
-<hr style="color:#1c6b13;width: 100%">
+<hr class="page-width-divider">
 
 <table width="100%" style="margin: 20px 0; font-size: 12pt;">
     <tr>


### PR DESCRIPTION
## Summary
- add a dedicated CSS rule to stretch the divider across the printable area in the passport summary PDF
- use the new class on the horizontal rule so it reaches the full page width in generated PDFs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8db6360b08326856e964da90528f6