### PR TITLE
Remove summary header and footer gaps

### DIFF
--- a/resources/views/passport/summary-print.blade.php
+++ b/resources/views/passport/summary-print.blade.php
@@ -8,7 +8,7 @@
             font-family: "Times New Roman", Times, serif;
             font-size: 12pt;
             line-height: 1.6;
-            margin: 0cm 1.5cm 1.5cm 1.5cm;
+            margin: 0cm 1.5cm 0cm 1.5cm;
         }
 
         .header {
@@ -94,7 +94,7 @@
 
         footer {
             position: fixed;
-            bottom: -20px;
+            bottom: 0;
             left: 0;
             right: 0;
             font-size: 10pt;

--- a/resources/views/passport/summary.blade.php
+++ b/resources/views/passport/summary.blade.php
@@ -10,15 +10,27 @@
             font-family: "Times New Roman", Times, serif;
             font-size: 12pt;
             background-color: #f8f9fa;
+            margin: 0;
+            padding: 0;
+        }
+
+        body.document-page main {
+            padding-top: 0 !important;
+            padding-bottom: 0 !important;
         }
 
         .document-card {
             background: #fff;
-            padding: 40px;
+            padding: 0 40px 32px;
             border-radius: 12px;
             box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
             max-width: 900px;
             margin: 0 auto;
+        }
+
+        .document-container {
+            padding-top: 0;
+            padding-bottom: 0;
         }
 
         .document-card .logo {
@@ -28,6 +40,7 @@
         .document-footer {
             border-top: 1px solid #198754;
             color: #198754;
+            padding-bottom: 0;
         }
 
         .signature-block {
@@ -51,7 +64,7 @@
 @endpush
 
 @section('content')
-<div class="container flex-grow-1 d-flex flex-column">
+<div class="container flex-grow-1 d-flex flex-column document-container">
     <div class="document-card">
         <div class="text-center mb-3">
             <img src="{{ asset('images/logo.png') }}" alt="Logo" class="logo mb-2">


### PR DESCRIPTION
## Summary
- remove the vertical padding in the web summary layout so the logo sits flush at the top and the footer touches the bottom of the page
- adjust the printable summary margins and footer position to eliminate whitespace above the logo and below the footer

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9224c0b7c8326a05c1b5487085143